### PR TITLE
655: Fix P2P Block bug

### DIFF
--- a/includes/Greenpeace/Planet4GPCHBlocks/Blocks/BaseBlock.php
+++ b/includes/Greenpeace/Planet4GPCHBlocks/Blocks/BaseBlock.php
@@ -48,15 +48,40 @@ class BaseBlock {
 
 		if ( $post !== null && has_blocks( $post->post_content ) ) {
 			$blocks = parse_blocks( $post->post_content );
-			foreach ( $blocks as $block ) {
-				if ( $block['blockName'] == $block_name ) {
-					return $block;
-				}
+
+			$found_blocks = self::find_block( $blocks, $block_name );
+
+			if ( array_key_exists( 0, $found_blocks ) ) {
+				return $found_blocks[0];
 			}
 		}
 
 		return false;
 	}
+
+	/**
+	 * Recursively finds blocks in parse_blocks output of page content.
+	 *
+	 * @param $blocks
+	 *
+	 * @return array
+	 */
+	static function find_block( $blocks, $block_name ) {
+		$list = array();
+
+		foreach ( $blocks as $block ) {
+			if ( $block_name === $block['blockName'] ) {
+				// add current item, if it's a heading block
+				$list[] = $block;
+			} elseif ( ! empty( $block['innerBlocks'] ) ) {
+				// or call the function recursively, to find heading blocks in inner blocks
+				$list = array_merge( $list, self::find_block( $block['innerBlocks'], $block_name ) );
+			}
+		}
+
+		return $list;
+	}
+
 
 
 	/**

--- a/includes/Greenpeace/Planet4GPCHBlocks/Blocks/P2PShareBlock.php
+++ b/includes/Greenpeace/Planet4GPCHBlocks/Blocks/P2PShareBlock.php
@@ -248,14 +248,15 @@ class P2PShareBlock extends BaseBlock {
 
 				// Get messages
 				if ( isset( $this->block_attributes[ $relatedBlockAttributes[ $channel ] ] ) && $this->block_attributes[ $relatedBlockAttributes[ $channel ] ] != null ) {
-
 					if ( $channel == 'whatsapp' ) {
-						$share_link = $this->generate_whatsapp_share_link( $this->get_share_message( $channel ) );
+						$share_link = $this->generate_whatsapp_share_link( $this->get_share_message( $channel, false, $data['postId'] ) );
 					} elseif ( $channel == 'telegram' ) {
-						$share_link = $this->generate_telegram_share_link( $this->block_attributes['shareLink']['url'], $this->get_share_message( $channel ) );
+						$share_link = $this->generate_telegram_share_link( $this->block_attributes['shareLink']['url'], $this->get_share_message( $channel, false, $data['postId'] ) );
 					}
 
-					$share_link_shortened = $this->get_shortened_link( $share_link, $channel, false );
+
+					$share_link_shortened = $this->get_shortened_link( $share_link, $channel, false, $data['postId'] );
+
 
 					$message = __( $this->block_attributes[ $relatedBlockAttributes[ $channel ] ], 'planet4-gpch-plugin-blocks' ) . ' ' . $share_link_shortened;
 
@@ -329,8 +330,9 @@ class P2PShareBlock extends BaseBlock {
 
 			// Replace CTA_LINK in email text
 			$link = $this->block_attributes['shareLink'];
+
 			if ( $link !== null ) {
-				$cta_link = $this->get_shortened_link( $link['url'], 'email' );
+				$cta_link = $this->get_shortened_link( $link['url'], 'email', true, $data['postId'] );
 			} else {
 				$cta_link = '';
 			}
@@ -372,7 +374,7 @@ class P2PShareBlock extends BaseBlock {
 	 * @return string
 	 * @throws \Exception
 	 */
-	private function get_share_message( $channel, $shortVersion = false ) {
+	private function get_share_message( $channel, $shortVersion = false, $postID = false ) {
 		if ( $shortVersion ) {
 			$text = $this->block_attributes['shareTextShort'];
 		} else {
@@ -386,7 +388,7 @@ class P2PShareBlock extends BaseBlock {
 		}
 
 		if ( $link !== null ) {
-			$link = $this->get_shortened_link( $link['url'], $channel );
+			$link = $this->get_shortened_link( $link['url'], $channel, true, $postID );
 		} else {
 			$link = '';
 		}
@@ -458,12 +460,14 @@ class P2PShareBlock extends BaseBlock {
 	 * @return mixed
 	 * @throws \Exception
 	 */
-	private function get_shortened_link( $url, $channel, $use_utm_tags = true ) {
+	private function get_shortened_link( $url, $channel, $use_utm_tags = true, $postID = false ) {
 		if ( $use_utm_tags ) {
 			$url = $this->create_utm_link( $url, $channel );
 		}
 
-		$postID = get_the_ID();
+		if ($postID === false) {
+			$postID = get_the_ID();
+		}
 
 		$meta_key = 'gpch_p2p_shortlink_' . md5( $url . $channel . $postID );
 


### PR DESCRIPTION
Links weren't generated correctly in multiple cases:
1. The block was nested inside of another block
2. The link had to be shortened when requested by XHR