### PR TITLE
ES-585: Decrease P2P Share Block margins

### DIFF
--- a/assets/css/source/blocks/_p2p-share.scss
+++ b/assets/css/source/blocks/_p2p-share.scss
@@ -1,7 +1,7 @@
 .wp-block-planet4-gpch-plugin-blocks-p2p-share {
 	max-width: 32em;
 	position: relative;
-	min-height: 450px;
+	min-height: 250px;
 	overflow: hidden;
 
 	.p2p-share-step {

--- a/src/blocks/P2PShare/P2PShareBlock-frontend.js
+++ b/src/blocks/P2PShare/P2PShareBlock-frontend.js
@@ -13,13 +13,13 @@ p2pStepElements.forEach((item) => {
 });
 document.querySelector('.p2p-share-step-1').classList.remove('hidden');
 
-// Resize parent element to max child height
+// Resize parent element currently shown step height
 function setParentHeight(upsizeOnly = false) {
 	let maxHeight = 0;
 	const currentHeight = p2pShareElement.offsetHeight;
 
 	p2pStepElements.forEach((item) => {
-		if (item.offsetHeight > maxHeight) {
+		if (! item.classList.contains('hidden') && item.offsetHeight > maxHeight) {
 			maxHeight = item.offsetHeight;
 		}
 	});
@@ -46,6 +46,8 @@ stepButtons.forEach((item) => {
 			elementToShow.style.visibility = 'visible';
 			elementToShow.classList.remove('hidden');
 		}
+
+		setParentHeight(true);
 	});
 });
 


### PR DESCRIPTION
Decrease the margins of the block on initial load to not show a gap to the next content.